### PR TITLE
Use `jl_adopt_thread` instead of AsyncCondition for interop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RustyObjectStore"
 uuid = "1b5eed3d-1f46-4baa-87f3-a4a892b23610"
-version = "0.6.5"
+version = "0.7.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
@@ -16,7 +16,7 @@ ReTestItems = "1"
 Sockets = "1"
 Test = "1"
 julia = "1.8"
-object_store_ffi_jll = "0.6.5"
+object_store_ffi_jll = "0.7.0"
 
 [extras]
 CloudBase = "85eb1798-d7c4-4918-bb13-c944d38e27ed"

--- a/src/RustyObjectStore.jl
+++ b/src/RustyObjectStore.jl
@@ -103,7 +103,8 @@ Base.@ccallable function panic_hook_wrapper()::Cint
 end
 
 Base.@ccallable function notify_result(task::Ptr{Nothing})::Cint
-    schedule(unsafe_pointer_to_objref(task))
+    t = unsafe_pointer_to_objref(task)
+    schedule(t)
     return 0
 end
 

--- a/src/RustyObjectStore.jl
+++ b/src/RustyObjectStore.jl
@@ -599,6 +599,7 @@ end
 function rust_message_to_reason(msg::AbstractString)
     if contains(msg, "tcp connect error: deadline has elapsed") ||
         contains(msg, "tcp connect error: Connection refused") ||
+        contains(msg, "connection error: Connection reset by peer") ||
         contains(msg, "error trying to connect: dns error")
         return ConnectionError()
     elseif contains(msg, "Client error with status")
@@ -626,7 +627,8 @@ function rust_message_to_reason(msg::AbstractString)
             return UnknownError()
         end
     elseif contains(msg, "connection closed before message completed") ||
-        contains(msg, "end of file before message length reached")
+        contains(msg, "end of file before message length reached") ||
+        contains(msg, "body from connection: Connection reset by peer")
         return EarlyEOF()
     elseif contains(msg, "timed out")
         return TimeoutError()

--- a/src/RustyObjectStore.jl
+++ b/src/RustyObjectStore.jl
@@ -605,6 +605,7 @@ function rust_message_to_reason(msg::AbstractString)
         contains(msg, "connection error")
         || contains(msg, "tcp connect error")
         || contains(msg, "error trying to connect")
+        || contains(msg, "client error (Connect)")
        ) && (
         contains(msg, "deadline has elapsed")
         || contains(msg, "Connection refused")

--- a/test/aws_s3_exception_tests.jl
+++ b/test/aws_s3_exception_tests.jl
@@ -33,7 +33,7 @@
                 @test false # Should have thrown an error
             catch err
                 @test err isa RustyObjectStore.GetException
-                @test err.msg == "failed to process get with error: Supplied buffer was too small"
+                @test occursin("Supplied buffer was too small", err.msg)
             end
         end
 

--- a/test/aws_s3_exception_tests.jl
+++ b/test/aws_s3_exception_tests.jl
@@ -253,6 +253,148 @@ end # @testitem
         return nrequests[]
     end
 
+    function dummy_cb(handle::Ptr{Cvoid})
+        return nothing
+    end
+
+    function test_tcp_reset(method)
+        @assert method === :GET || method === :PUT
+        nrequests = Ref(0)
+
+        (port, tcp_server) = Sockets.listenany(8082)
+        @async begin
+            while true
+                sock = Sockets.accept(tcp_server)
+                _ = read(sock, 4)
+                nrequests[] += 1
+                ccall(
+                    :uv_tcp_close_reset,
+                    Cint,
+                    (Ptr{Cvoid}, Ptr{Cvoid}),
+                    sock.handle, @cfunction(dummy_cb, Cvoid, (Ptr{Cvoid},))
+                )
+            end
+        end
+
+        baseurl = "http://127.0.0.1:$port"
+        conf = AWSConfig(;
+            region=region,
+            bucket_name=container,
+            access_key_id=dummy_access_key_id,
+            secret_access_key=dummy_secret_access_key,
+            host=baseurl,
+            opts=ClientOptions(;
+                max_retries=max_retries,
+                retry_timeout_secs=retry_timeout_secs
+            )
+        )
+
+        try
+            method === :GET && get_object!(zeros(UInt8, 5), "blob", conf)
+            method === :PUT && put_object(codeunits("a,b,c"), "blob", conf)
+            @test false # Should have thrown an error
+        catch e
+            method === :GET && @test e isa RustyObjectStore.GetException
+            method === :PUT && @test e isa RustyObjectStore.PutException
+            @test occursin("reset by peer", e.msg)
+            @test is_connection(e)
+        finally
+            close(tcp_server)
+        end
+        return nrequests[]
+    end
+
+    function test_get_stream_reset()
+        nrequests = Ref(0)
+
+        (port, tcp_server) = Sockets.listenany(8083)
+        http_server = HTTP.listen!(tcp_server) do http::HTTP.Stream
+            nrequests[] += 1
+            HTTP.setstatus(http, 200)
+            HTTP.setheader(http, "Content-Length" => "20")
+            HTTP.startwrite(http)
+            write(http, "not enough")
+            socket = HTTP.IOExtras.tcpsocket(HTTP.Connections.getrawstream(http))
+            ccall(
+                :uv_tcp_close_reset,
+                Cint,
+                (Ptr{Cvoid}, Ptr{Cvoid}),
+                socket.handle, @cfunction(dummy_cb, Cvoid, (Ptr{Cvoid},))
+            )
+            close(http.stream)
+        end
+
+        baseurl = "http://127.0.0.1:$port"
+        conf = AWSConfig(;
+            region=region,
+            bucket_name=container,
+            access_key_id=dummy_access_key_id,
+            secret_access_key=dummy_secret_access_key,
+            host=baseurl,
+            opts=ClientOptions(;
+                max_retries=max_retries,
+                retry_timeout_secs=retry_timeout_secs
+            )
+        )
+
+        try
+            get_object!(zeros(UInt8, 20), "blob", conf)
+            @test false # Should have thrown an error
+        catch e
+            @test e isa RustyObjectStore.GetException
+            @test occursin("Connection reset by peer", e.msg)
+            @test is_early_eof(e)
+        finally
+            Threads.@spawn HTTP.forceclose(http_server)
+        end
+        # wait(http_server)
+        return nrequests[]
+    end
+
+    function test_get_stream_timeout()
+        nrequests = Ref(0)
+
+        (port, tcp_server) = Sockets.listenany(8083)
+        http_server = HTTP.listen!(tcp_server) do http::HTTP.Stream
+            nrequests[] += 1
+            HTTP.setstatus(http, 200)
+            HTTP.setheader(http, "Content-Length" => "20")
+            HTTP.setheader(http, "Last-Modified" => "Tue, 15 Oct 2019 12:45:26 GMT")
+            HTTP.setheader(http, "ETag" => "123")
+            HTTP.startwrite(http)
+            write(http, "not enough")
+            sleep(10)
+            close(http.stream)
+        end
+
+        baseurl = "http://127.0.0.1:$port"
+        conf = AWSConfig(;
+            region=region,
+            bucket_name=container,
+            access_key_id=dummy_access_key_id,
+            secret_access_key=dummy_secret_access_key,
+            host=baseurl,
+            opts=ClientOptions(;
+                max_retries=max_retries,
+                retry_timeout_secs=retry_timeout_secs,
+                request_timeout_secs
+            )
+        )
+
+        try
+            get_object!(zeros(UInt8, 20), "blob", conf)
+            @test false # Should have thrown an error
+        catch e
+            @test e isa RustyObjectStore.GetException
+            @test occursin("operation timed out", e.msg)
+            @test is_timeout(e)
+        finally
+            Threads.@spawn HTTP.forceclose(http_server)
+        end
+        # wait(http_server)
+        return nrequests[]
+    end
+
     function test_status(method, response_status, headers=nothing)
         @assert method === :GET || method === :PUT
         nrequests = Ref(0)
@@ -534,8 +676,25 @@ end # @testitem
         @test nrequests == 1 + max_retries
     end
 
+    @testset "TCP reset" begin
+        nrequests = test_tcp_reset(:GET)
+        @test nrequests == 1 + max_retries
+        nrequests = test_tcp_reset(:PUT)
+        @test nrequests == 1 + max_retries
+    end
+
     @testset "Incomplete GET body" begin
         nrequests = test_get_stream_error()
+        @test nrequests == 1 + max_retries
+    end
+
+    @testset "Incomplete GET body reset" begin
+        nrequests = test_get_stream_reset()
+        @test nrequests == 1 + max_retries
+    end
+
+    @testset "Incomplete GET body timeout" begin
+        nrequests = test_get_stream_timeout()
         @test nrequests == 1 + max_retries
     end
 

--- a/test/azure_blobs_exception_tests.jl
+++ b/test/azure_blobs_exception_tests.jl
@@ -351,6 +351,148 @@ end # @testitem
         return nrequests[]
     end
 
+    function dummy_cb(handle::Ptr{Cvoid})
+        return nothing
+    end
+
+    function test_tcp_reset(method)
+        @assert method === :GET || method === :PUT
+        nrequests = Ref(0)
+
+        (port, tcp_server) = Sockets.listenany(8082)
+        @async begin
+            while true
+                sock = Sockets.accept(tcp_server)
+                _ = read(sock, 4)
+                nrequests[] += 1
+                ccall(
+                    :uv_tcp_close_reset,
+                    Cint,
+                    (Ptr{Cvoid}, Ptr{Cvoid}),
+                    sock.handle, @cfunction(dummy_cb, Cvoid, (Ptr{Cvoid},))
+                )
+            end
+        end
+
+        baseurl = "http://127.0.0.1:$port/$account/$container/"
+        conf = AzureConfig(;
+            storage_account_name=account,
+            container_name=container,
+            storage_account_key=shared_key_from_azurite,
+            host=baseurl,
+            opts=ClientOptions(;
+                max_retries=max_retries,
+                retry_timeout_secs=retry_timeout_secs,
+                request_timeout_secs
+            )
+        )
+
+        try
+            method === :GET && get_object!(zeros(UInt8, 5), "blob", conf)
+            method === :PUT && put_object(codeunits("a,b,c"), "blob", conf)
+            @test false # Should have thrown an error
+        catch e
+            method === :GET && @test e isa RustyObjectStore.GetException
+            method === :PUT && @test e isa RustyObjectStore.PutException
+            @test occursin("reset by peer", e.msg)
+            @test is_connection(e)
+        finally
+            close(tcp_server)
+        end
+        return nrequests[]
+    end
+
+    function test_get_stream_reset()
+        nrequests = Ref(0)
+
+        (port, tcp_server) = Sockets.listenany(8083)
+        http_server = HTTP.listen!(tcp_server) do http::HTTP.Stream
+            nrequests[] += 1
+            HTTP.setstatus(http, 200)
+            HTTP.setheader(http, "Content-Length" => "20")
+            HTTP.setheader(http, "Last-Modified" => "Tue, 15 Oct 2019 12:45:26 GMT")
+            HTTP.setheader(http, "ETag" => "123")
+            HTTP.startwrite(http)
+            write(http, "not enough")
+            socket = HTTP.IOExtras.tcpsocket(HTTP.Connections.getrawstream(http))
+            ccall(
+                :uv_tcp_close_reset,
+                Cint,
+                (Ptr{Cvoid}, Ptr{Cvoid}),
+                socket.handle, @cfunction(dummy_cb, Cvoid, (Ptr{Cvoid},))
+            )
+            close(http.stream)
+        end
+
+        baseurl = "http://127.0.0.1:$port/$account/$container/"
+        conf = AzureConfig(;
+            storage_account_name=account,
+            container_name=container,
+            storage_account_key=shared_key_from_azurite,
+            host=baseurl,
+            opts=ClientOptions(;
+                max_retries=max_retries,
+                retry_timeout_secs=retry_timeout_secs
+            )
+        )
+
+        try
+            get_object!(zeros(UInt8, 20), "blob", conf)
+            @test false # Should have thrown an error
+        catch e
+            @test e isa RustyObjectStore.GetException
+            @test occursin("Connection reset by peer", e.msg)
+            @test is_early_eof(e)
+        finally
+            Threads.@spawn HTTP.forceclose(http_server)
+        end
+        # wait(http_server)
+        return nrequests[]
+    end
+
+    function test_get_stream_timeout()
+        nrequests = Ref(0)
+
+        (port, tcp_server) = Sockets.listenany(8083)
+        http_server = HTTP.listen!(tcp_server) do http::HTTP.Stream
+            nrequests[] += 1
+            HTTP.setstatus(http, 200)
+            HTTP.setheader(http, "Content-Length" => "20")
+            HTTP.setheader(http, "Last-Modified" => "Tue, 15 Oct 2019 12:45:26 GMT")
+            HTTP.setheader(http, "ETag" => "123")
+            HTTP.startwrite(http)
+            write(http, "not enough")
+            sleep(10)
+            close(http.stream)
+        end
+
+        baseurl = "http://127.0.0.1:$port/$account/$container/"
+        conf = AzureConfig(;
+            storage_account_name=account,
+            container_name=container,
+            storage_account_key=shared_key_from_azurite,
+            host=baseurl,
+            opts=ClientOptions(;
+                max_retries=max_retries,
+                retry_timeout_secs=retry_timeout_secs,
+                request_timeout_secs
+            )
+        )
+
+        try
+            get_object!(zeros(UInt8, 20), "blob", conf)
+            @test false # Should have thrown an error
+        catch e
+            @test e isa RustyObjectStore.GetException
+            @test occursin("operation timed out", e.msg)
+            @test is_timeout(e)
+        finally
+            Threads.@spawn HTTP.forceclose(http_server)
+        end
+        # wait(http_server)
+        return nrequests[]
+    end
+
     function test_timeout(method, message, wait_secs::Int = 60)
         @assert method === :GET || method === :PUT
         nrequests = Ref(0)
@@ -594,8 +736,25 @@ end # @testitem
         @test nrequests == 1 + max_retries
     end
 
+    @testset "TCP reset" begin
+        nrequests = test_tcp_reset(:GET)
+        @test nrequests == 1 + max_retries
+        nrequests = test_tcp_reset(:PUT)
+        @test nrequests == 1 + max_retries
+    end
+
     @testset "Incomplete GET body" begin
         nrequests = test_get_stream_error()
+        @test nrequests == 1 + max_retries
+    end
+
+    @testset "Incomplete GET body reset" begin
+        nrequests = test_get_stream_reset()
+        @test nrequests == 1 + max_retries
+    end
+
+    @testset "Incomplete GET body timeout" begin
+        nrequests = test_get_stream_timeout()
         @test nrequests == 1 + max_retries
     end
 

--- a/test/azure_blobs_exception_tests.jl
+++ b/test/azure_blobs_exception_tests.jl
@@ -31,7 +31,7 @@
                 @test false # Should have thrown an error
             catch err
                 @test err isa RustyObjectStore.GetException
-                @test err.msg == "failed to process get with error: Supplied buffer was too small"
+                @test occursin("Supplied buffer was too small", err.msg)
             end
         end
 
@@ -51,7 +51,7 @@
                 @test false # Should have thrown an error
             catch err
                 @test err isa RustyObjectStore.GetException
-                @test err.msg == "failed to process get with error: Supplied buffer was too small"
+                @test occursin("Supplied buffer was too small", err.msg)
             end
         end
 


### PR DESCRIPTION
This PR introduces a number of improvements and fixes to RustyObjectStore:
- using jl_adopt_thread instead of AsyncCondition for reducing contention in the Julia <-> Rust interop as well as fixing the EOFErrors we saw a couple times
- New task scheduling on the Rust side that allows us to roughly saturate a 100Gbps NIC
- Improved retry reporting on error
- A fix for when we fail to retry due to the client getting evicted from the Rust cache
- Properly destruct complex objects on the Rust side inside tokio threads